### PR TITLE
Feature/create offers

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,0 +1,39 @@
+class Offer < ApplicationRecord
+  monetize :fixed_price_cents, allow_nil: true
+
+  has_many :product_offers, dependent: :destroy
+  has_many :products, through: :product_offers
+
+  enum :discount_type, {
+    buy_one_take_one: 0,
+    quantity_discount: 1
+  }
+
+  enum :rate_type, {
+    fixed_price: 0,
+    percentage_rate: 1
+  }
+
+  validates :name, presence: true, uniqueness: true
+  validates :discount_type, presence: true
+  validates :rate_type, presence: true, if: :quantity_discount?
+  validates :fixed_price_cents, presence: true, numericality: { greater_than: 0 }, if: :requires_fixed_price?
+  validates :percentage_rate, presence: true, if: :requires_percentage_rate?
+  validates :percentage_rate,
+    numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+    allow_nil: true
+  validates :minimum_quantity,
+    presence: true,
+    numericality: { only_integer: true, greater_than: 1 },
+    if: -> { quantity_discount? }
+
+  private
+
+  def requires_fixed_price?
+    quantity_discount? && fixed_price?
+  end
+
+  def requires_percentage_rate?
+    quantity_discount? && percentage_rate?
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,8 @@
 class Product < ApplicationRecord
   monetize :price_cents
 
+  has_many :product_offers, dependent: :destroy
+  has_many :offers, through: :product_offers
+
   validates :product_code, length: { is: 3, message: "must be exactly 3 characters" }
 end

--- a/app/models/product_offer.rb
+++ b/app/models/product_offer.rb
@@ -1,0 +1,6 @@
+class ProductOffer < ApplicationRecord
+  belongs_to :product
+  belongs_to :offer
+
+  validates :product_id, uniqueness: { scope: :offer_id }
+end

--- a/db/migrate/20250906111436_create_offers.rb
+++ b/db/migrate/20250906111436_create_offers.rb
@@ -1,0 +1,15 @@
+class CreateOffers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :offers do |t|
+      t.string :name, null: false
+      t.text :description
+      t.integer :discount_type
+      t.integer :rate_type
+      t.decimal :percentage_rate, precision: 5, scale: 2
+      t.monetize :fixed_price
+      t.integer :minimum_quantity
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250906113820_create_product_offers.rb
+++ b/db/migrate/20250906113820_create_product_offers.rb
@@ -1,0 +1,12 @@
+class CreateProductOffers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :product_offers do |t|
+      t.references :product, null: false, foreign_key: true
+      t.references :offer, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    
+    add_index :product_offers, [:product_id, :offer_id], unique: true
+  end
+end

--- a/db/migrate/20250906113820_create_product_offers.rb
+++ b/db/migrate/20250906113820_create_product_offers.rb
@@ -6,7 +6,7 @@ class CreateProductOffers < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
-    
-    add_index :product_offers, [:product_id, :offer_id], unique: true
+
+    add_index :product_offers, [ :product_id, :offer_id ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_06_045450) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_06_113820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,6 +29,29 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_045450) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "offers", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.integer "discount_type"
+    t.integer "rate_type"
+    t.decimal "percentage_rate", precision: 5, scale: 2
+    t.integer "fixed_price_cents", default: 0, null: false
+    t.string "fixed_price_currency", default: "EUR", null: false
+    t.integer "minimum_quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "product_offers", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.bigint "offer_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["offer_id"], name: "index_product_offers_on_offer_id"
+    t.index ["product_id", "offer_id"], name: "index_product_offers_on_product_id_and_offer_id", unique: true
+    t.index ["product_id"], name: "index_product_offers_on_product_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "product_code", null: false
     t.string "name", null: false
@@ -41,4 +64,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_06_045450) do
 
   add_foreign_key "basket_items", "baskets"
   add_foreign_key "basket_items", "products"
+  add_foreign_key "product_offers", "offers"
+  add_foreign_key "product_offers", "products"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,6 +25,39 @@ end
 
 puts "Created #{Product.count} products"
 
+offer_1 = Offer.find_or_create_by!(name: 'Green Tea BOGO') do |offer|
+  offer.description = 'Buy one green tea, get one free'
+  offer.discount_type = :buy_one_take_one
+  offer.minimum_quantity = 2
+end
+
+green_tea = Product.find_by!(product_code: 'GR1')
+ProductOffer.find_or_create_by!(product: green_tea, offer: offer_1)
+
+offer_2 = Offer.find_or_create_by!(name: 'Strawberry Bulk Discount') do |offer|
+  offer.description = 'Buy 3 or more strawberries for 4.50€ each'
+  offer.discount_type = :quantity_discount
+  offer.rate_type = :fixed_price
+  offer.fixed_price_cents = 450
+  offer.minimum_quantity = 3
+end
+
+strawberry = Product.find_by!(product_code: 'SR1')
+ProductOffer.find_or_create_by!(product: strawberry, offer: offer_2)
+
+offer_3 = Offer.find_or_create_by!(name: 'Coffee Bulk Discount') do |offer|
+  offer.description = 'Buy 3 or more coffees for 2/3 of original price'
+  offer.discount_type = :quantity_discount
+  offer.rate_type = :percentage_rate
+  offer.percentage_rate = 66.66
+  offer.minimum_quantity = 3
+end
+
+coffee = Product.find_by!(product_code: 'CF1')
+ProductOffer.find_or_create_by!(product: coffee, offer: offer_3)
+
+puts "Created #{Offer.count} offers"
+
 baskets_data = [
   {
     "GR1" => 3,

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :offer do
+    name { "Sample Offer" }
+    description { "A great promotional offer" }
+    discount_type { :quantity_discount }
+    rate_type { :percentage_rate }
+    percentage_rate { 10.0 }
+    minimum_quantity { 2 }
+
+    trait :buy_one_take_one do
+      discount_type { :buy_one_take_one }
+      rate_type { nil }
+      percentage_rate { nil }
+      fixed_price_cents { nil }
+      minimum_quantity { 2 }
+    end
+
+    trait :fixed_price_discount do
+      rate_type { :fixed_price }
+      percentage_rate { nil }
+      fixed_price_cents { 199 }
+    end
+  end
+end

--- a/spec/factories/product_offers.rb
+++ b/spec/factories/product_offers.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :product_offer do
+    product { nil }
+    offer { nil }
+  end
+end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe Offer, type: :model do
+  describe 'associations' do
+    it { should have_many(:product_offers).dependent(:destroy) }
+    it { should have_many(:products).through(:product_offers) }
+  end
+
+  describe 'enums' do
+    it { should define_enum_for(:discount_type).with_values(buy_one_take_one: 0, quantity_discount: 1) }
+    it { should define_enum_for(:rate_type).with_values(fixed_price: 0, percentage_rate: 1) }
+  end
+
+  describe 'validations' do
+    context 'when discount_type is buy_one_take_one' do
+      let(:offer) { build(:offer, discount_type: :buy_one_take_one) }
+
+      it 'allows all nullable fields to be blank' do
+        offer.rate_type = nil
+        offer.percentage_rate = nil
+        offer.fixed_price_cents = nil
+        offer.minimum_quantity = nil
+
+        expect(offer).to be_valid
+      end
+    end
+
+    context 'when discount_type is quantity_discount' do
+      let(:offer) { build(:offer, discount_type: :quantity_discount) }
+
+      it 'requires rate_type to be present' do
+        offer.rate_type = nil
+        expect(offer).not_to be_valid
+        expect(offer.errors[:rate_type]).to include("can't be blank")
+      end
+
+      context 'and rate_type is fixed_price' do
+        it 'requires fixed_price_cents to be present' do
+          offer.rate_type = :fixed_price
+          offer.fixed_price_cents = nil
+
+          expect(offer).not_to be_valid
+          expect(offer.errors[:fixed_price_cents]).to include("can't be blank")
+        end
+
+        it 'is valid with fixed_price_cents present' do
+          offer.rate_type = :fixed_price
+          offer.fixed_price_cents = 100
+
+          expect(offer).to be_valid
+        end
+      end
+
+      context 'and rate_type is percentage_rate' do
+        it 'requires percentage_rate to be present' do
+          offer.rate_type = :percentage_rate
+          offer.percentage_rate = nil
+
+          expect(offer).not_to be_valid
+          expect(offer.errors[:percentage_rate]).to include("can't be blank")
+        end
+
+        it 'is valid with percentage_rate present' do
+          offer.rate_type = :percentage_rate
+          offer.percentage_rate = 10.5
+
+          expect(offer).to be_valid
+        end
+
+        it 'validates percentage_rate is between 0 and 100' do
+          offer.rate_type = :percentage_rate
+
+          offer.percentage_rate = -1
+          expect(offer).not_to be_valid
+
+          offer.percentage_rate = 101
+          expect(offer).not_to be_valid
+
+          offer.percentage_rate = 50
+          expect(offer).to be_valid
+        end
+      end
+    end
+
+    describe 'name validation' do
+      it 'requires name to be present' do
+        offer = build(:offer, name: nil)
+        expect(offer).not_to be_valid
+        expect(offer.errors[:name]).to include("can't be blank")
+      end
+    end
+
+    describe 'discount_type validation' do
+      it 'requires discount_type to be present' do
+        offer = build(:offer, discount_type: nil)
+        expect(offer).not_to be_valid
+        expect(offer.errors[:discount_type]).to include("can't be blank")
+      end
+    end
+
+    describe 'minimum_quantity validation for quantity_discount' do
+      let(:offer) { build(:offer, discount_type: :quantity_discount, rate_type: :percentage_rate, percentage_rate: 10) }
+
+      it 'requires minimum_quantity to be present' do
+        offer.minimum_quantity = nil
+
+        expect(offer).not_to be_valid
+        expect(offer.errors[:minimum_quantity]).to include("can't be blank")
+      end
+
+      it 'requires minimum_quantity to be greater than 1' do
+        offer.minimum_quantity = 0
+        expect(offer).not_to be_valid
+
+        offer.minimum_quantity = 1
+        expect(offer).not_to be_valid
+
+        offer.minimum_quantity = 2
+        expect(offer).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/product_offer_spec.rb
+++ b/spec/models/product_offer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProductOffer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR does the folllowing:

* Create Offer model - handles all offers available
* Create ProductOffer model - allows the ability to assign offers to a product

Design consideration
* Contemplated creating OfferCondition model. This would allow creating multiple conditions on an offer (`minimum_quantity`, `maximum_quantity`, etc). Creating OfferCondition could also improve readability on how to setup discount_types.
* Made a judgment call to lump all conditions for existing offer types under offer and use model validations instead for the purpose of MVP and eliminate added complexity.